### PR TITLE
Implement configurable timeouts for servicebus namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,26 @@ Type: `map(string)`
 
 Default: `null`
 
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: - `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace.
+- `delete` - (Defaults to 30 minutes) Used when deleting the ServiceBus Namespace.
+- `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace.
+- `update` - (Defaults to 30 minutes) Used when updating the ServiceBus Namespace.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
+
 ### <a name="input_topics"></a> [topics](#input\_topics)
 
 Description:   Defaults to `{}`. Ignored for Basic. A map of topics to create.  

--- a/examples/public-restricted-access/README.md
+++ b/examples/public-restricted-access/README.md
@@ -12,7 +12,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
-
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6"

--- a/examples/public-restricted-access/README.md
+++ b/examples/public-restricted-access/README.md
@@ -30,7 +30,7 @@ provider "azurerm" {
 
 locals {
   prefix = "resPub"
-  skus   = ["Standard", "Premium"]
+  skus   = ["Basic", "Standard", "Premium"]
 }
 
 module "regions" {

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ resource "azurerm_servicebus_namespace" "this" {
   }
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete

--- a/main.tf
+++ b/main.tf
@@ -65,12 +65,12 @@ resource "azurerm_servicebus_namespace" "this" {
   }
 
   dynamic "timeouts" {
-    for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+    for_each = var.timeouts == null ? [] : [var.timeouts]
     content {
       create = timeouts.value.create
-      update = timeouts.value.update
       delete = timeouts.value.delete
       read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,15 @@ resource "azurerm_servicebus_namespace" "this" {
       }
     }
   }
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   # These cases are handled in the normalized_xxx variables. Serves as unit testing in case of future changes to those variables
   lifecycle {
@@ -61,16 +70,6 @@ resource "azurerm_servicebus_namespace" "this" {
     precondition {
       condition     = var.sku != local.premium_sku_name ? local.normalized_capacity == 0 : true
       error_message = "Capacity parameter requires Premium SKU"
-    }
-  }
-
-  dynamic "timeouts" {
-    for_each = var.timeouts == null ? [] : [var.timeouts]
-    content {
-      create = timeouts.value.create
-      delete = timeouts.value.delete
-      read   = timeouts.value.read
-      update = timeouts.value.update
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,16 @@ resource "azurerm_servicebus_namespace" "this" {
       error_message = "Capacity parameter requires Premium SKU"
     }
   }
+
+  dynamic "timeouts" {
+    for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+    content {
+      create = timeouts.value.create
+      update = timeouts.value.update
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+    }
+  }
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,22 @@ variable "sku" {
   }
 }
 
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<-EOT
+ - `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the ServiceBus Namespace.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace.
+ - `update` - (Defaults to 30 minutes) Used when updating the ServiceBus Namespace.
+EOT  
+}
+
 variable "zone_redundant" {
   type        = bool
   default     = null


### PR DESCRIPTION
## Description

Added configurable timeouts to the service bus namespace to allow for Azure taking longer than the default time to provision the resource.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
